### PR TITLE
Update config.m4 for PHP 5.6

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -22,6 +22,8 @@ if test "$PHP_PDO_SQLCIPHER" != "no"; then
         pdo_inc_path=$prefix/include/php5/ext
     elif test -f $prefix/include/php/5.5/php/ext/pdo/php_pdo_driver.h; then
         pdo_inc_path=$prefix/include/php/5.5/php/ext
+    elif test -f $prefix/include/php/5.6/php/ext/pdo/php_pdo_driver.h; then
+        pdo_inc_path=$prefix/include/php/5.6/php/ext
     else
         AC_MSG_ERROR([Cannot find php_pdo_driver.h.])
     fi


### PR DESCRIPTION
This is just a minor addition to check for a `PHP 5.6` extensions directory. 